### PR TITLE
add frame id to the message to make rvis2 happy

### DIFF
--- a/src/ros_vision/src/apriltags_cuda/src/apriltags_cuda_node.cu
+++ b/src/ros_vision/src/apriltags_cuda/src/apriltags_cuda_node.cu
@@ -122,6 +122,7 @@ private:
         // Publish the message to the viewer
         auto outgoing_msg = cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", bgr_img).toImageMsg();
         outgoing_msg->header.stamp = this->now();
+        outgoing_msg->header.frame_id = "apriltag_detections";
         publisher_->publish(*outgoing_msg);
 
         auto end = std::chrono::high_resolution_clock::now();

--- a/src/ros_vision/src/usb_camera/src/usb_camera_node.cpp
+++ b/src/ros_vision/src/usb_camera/src/usb_camera_node.cpp
@@ -29,7 +29,7 @@ public:
         cap_.set(cv::CAP_PROP_FRAME_HEIGHT, 800);
         cap_.set(cv::CAP_PROP_CONVERT_RGB, true);
 
-        publisher_ = this->create_publisher<sensor_msgs::msg::Image>(topic_name, 1);
+        publisher_ = this->create_publisher<sensor_msgs::msg::Image>(topic_name, 10);
 
         RCLCPP_INFO(this->get_logger(), "Width: '%d'", static_cast<int>(cap_.get(cv::CAP_PROP_FRAME_WIDTH)));
         RCLCPP_INFO(this->get_logger(), "Height: '%d'", static_cast<int>(cap_.get(cv::CAP_PROP_FRAME_HEIGHT)));
@@ -52,6 +52,7 @@ private:
 
         auto msg = cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", frame).toImageMsg();
         msg->header.stamp = this->now();
+        msg->header.frame_id = "camera_frame";  // <-- add this line
 
         publisher_->publish(*msg);
     }


### PR DESCRIPTION
visualizers like rvis2 need a frame id otherwise they won't display the message data